### PR TITLE
#43 Added proper validation of reset form, removed validation from signin form

### DIFF
--- a/resolver/controllers/user.py
+++ b/resolver/controllers/user.py
@@ -3,7 +3,7 @@ from functools import update_wrapper
 from resolver import app
 from resolver.model import User
 from resolver.database import db
-from resolver.forms import SigninForm, UserForm
+from resolver.forms import SigninForm, UserForm, ResetForm
 from resolver.util import log
 
 def check_privilege(func):
@@ -98,25 +98,28 @@ def admin_delete_user(username):
 @app.route('/resolver/user/<username>')
 @check_privilege
 def admin_view_user(username):
+    form = ResetForm()
     user = User.query.filter(User.username == username).first()
     if not user:
         flash("User not found", "warning")
         return redirect("/resolver/user")
-    return render_template("resolver/user.html", title="Edit user", user=user)
+    return render_template("resolver/user.html", title="Edit user", user=user, form=form)
 
 @app.route('/resolver/user/<username>', methods=["POST"])
 @check_privilege
 def admin_change_user_password(username):
+    form = ResetForm()
     user = User.query.filter(User.username == username).first()
-    if not user:
-        flash("User not found", "warning")
-        return redirect("/resolver/user")
-    if request.form['password'] == "":
-        flash("Password can not be empty", "warning")
-        return render_template("resolver/user.html", title="Edit user",
-                               user=user)
-    user.change_password(request.form['password'])
-    db.session.commit()
-    #log("changed the password of user `%s'" % user.username)
-    flash("Password changed succesfully", "success")
-    return admin_view_user(username)
+    if form.validate():
+        if not user:
+            flash("User not found", "warning")
+            return redirect("/resolver/user")
+        # TODO: Do we really need this?
+        if form.password.data != form.confirm.data:
+            flash("The two passwords do not match.", "warning")
+            return redirect("/resolver/user/%s" % username)
+        user.change_password(form.password.data)
+        db.session.commit()
+        #log("changed the password of user `%s'" % user.username)
+        flash("Password changed succesfully", "success")
+    return render_template("resolver/user.html", title="Edit user", user=user, form=form)

--- a/resolver/forms.py
+++ b/resolver/forms.py
@@ -34,12 +34,20 @@ class RepresentationForm(DocumentForm):
                                   validators.Length(max=64)])
 
 class SigninForm(Form):
+    username = StringField('Username', [validators.required()])
+
+    password = PasswordField('Password', [validators.required()])
+
+class UserForm(Form):
     username = StringField('Username', [validators.required(),
                                         validators.Length(min=3, max=32)])
     password = PasswordField('Password', [validators.required(),
                                           validators.Length(min=7, max=64)])
+    confirm = PasswordField('Confirm', [validators.required()])
 
-class UserForm(SigninForm):
+class ResetForm(Form):
+    password = PasswordField('Password', [validators.required(),
+                                          validators.Length(min=7, max=64)])
     confirm = PasswordField('Confirm', [validators.required()])
 
 class SettingsForm(Form):

--- a/resolver/templates/resolver/user.html
+++ b/resolver/templates/resolver/user.html
@@ -1,3 +1,4 @@
+{% from "_formhelpers.html" import render_field %}
 {% extends "resolver/layout.html" %}
 {% block body %}
     <div class="panel panel-default">
@@ -13,16 +14,19 @@
           <tr>
             <td><strong>Change password</strong></td>
             <td>
-              <form class="form-inline" role="form" method="POST">
+              <form action="/resolver/user/{{ user.username }}" class="form-horizontal" role="form" method="POST">
                 <div class="form-group">
-                  <label class="sr-only" for="password">Password</label>
-                  <input type="password" class="form-control" id="password" name="password" placeholder="New password">
-                    <input type="hidden" name="csrf_token" value="{{  csrf_token () }}" />
+                  {{ render_field(form.password, placeholder="New password") }}
                 </div>
                 <div class="form-group">
+                  {{ render_field(form.confirm, placeholder="Confirm new password") }}
+                </div>
+                <div class="form-group">
+                  <div class="col-sm-offset-2 col-sm-10">
                     {{ form.csrf_token }}
+                    <button type="submit" class="btn btn-default">Save</button>
+                  </div>
                 </div>
-                <button type="submit" class="btn btn-default">Save</button>
               </form>
             </td>
           </tr>


### PR DESCRIPTION
This commit:
- Adds a confirm field to the reset password form
- Uses the proper `render_field` macro in `user.html`
- Uses proper wtform validation instead of direct request.form handling
- Splits out the form classes in forms.py 
- Removes the unnecessary validation from the sign in form
