### PR TITLE
Fixes #59: missing http:// scheme  will cause faulty urls.

### DIFF
--- a/resolver/model/data.py
+++ b/resolver/model/data.py
@@ -3,6 +3,8 @@ from resolver.database import db
 from resolver.model import Document
 from resolver.util import log
 import resolver.kvstore as kvstore
+import urllib
+import urlparse
 
 data_formats = ['html', 'json', 'xml', 'pdf', 'csv']
 
@@ -45,6 +47,13 @@ class Data(Document):
         uri = app.config['BASE_URL']
         uri += '/collection/%s/data/%s/%s' % (self.entity.type, self.entity_id,
                                               self.format)
+
+        p = urlparse.urlparse(uri, 'http')
+        netloc = p.netloc or p.path
+        path = p.path if p.netloc else ''
+        p = urlparse.ParseResult('http', netloc, path, *p[3:])
+        uri = p.geturl()
+
         uris = [uri]
 
         if kvstore.get('titles_enabled'):

--- a/resolver/model/entity.py
+++ b/resolver/model/entity.py
@@ -6,6 +6,8 @@ from resolver.exception import EntityPIDExistsException,\
     EntityCollisionException
 from resolver.util import cleanID, log
 import resolver.kvstore as kvstore
+import urllib
+import urlparse
 
 ID_MAX = 64
 SLUG_MAX = 64
@@ -54,6 +56,12 @@ class Entity(db.Model):
     @property
     def persistent_uri(self):
         url = app.config['BASE_URL']+'/collection/%s' % self.id
+
+        p = urlparse.urlparse(url, 'http')
+        netloc = p.netloc or p.path
+        path = p.path if p.netloc else ''
+        p = urlparse.ParseResult('http', netloc, path, *p[3:])
+        url = p.geturl()
 
         if kvstore.get('titles_enabled'):
             return [url, url+'/%s'%self.slug]

--- a/resolver/model/representation.py
+++ b/resolver/model/representation.py
@@ -3,6 +3,8 @@ from resolver.database import db
 from resolver.model import Document
 from resolver.util import log
 import resolver.kvstore as kvstore
+import urllib
+import urlparse
 
 LABEL_MAX = 64
 
@@ -44,14 +46,27 @@ class Representation(Document):
         uri += '/collection/%s/representation/%s/%s' % (self.entity.type,
                                                         self.entity_id,
                                                         self.order)
+
+        p = urlparse.urlparse(uri, 'http')
+        netloc = p.netloc or p.path
+        path = p.path if p.netloc else ''
+        p = urlparse.ParseResult('http', netloc, path, *p[3:])
+        uri = p.geturl()
+
         uris = [uri]
 
         if kvstore.get('titles_enabled'):
             uris.append(uri+'/'+self.entity.slug)
         if self.reference:
-            uris.append(app.config['BASE_URL'] +
-                        '/collection/%s/representation/%s' % (self.entity.type,
-                                                              self.entity_id))
+            uri = app.config['BASE_URL'] + '/collection/%s/representation/%s' % (self.entity.type, self.entity_id)
+
+            p = urlparse.urlparse(uri, 'http')
+            netloc = p.netloc or p.path
+            path = p.path if p.netloc else ''
+            p = urlparse.ParseResult('http', netloc, path, *p[3:])
+            uri = p.geturl()
+
+            uris.append(uri)
 
         return uris
 


### PR DESCRIPTION
From the resolver.cfg file:

> Root URL of the resolver, without trailing /, and with scheme.
> BASE_URL = "resolver.box"

So, I forgot to add the http:// in front of the base_url. Technically it's still a valid domain name / url. There's no validation whatsoever, which will cause persistent URI's to not link correctly.

This PR will add http:// to the domain if it is missing in configuration. This allows you to configure it like this:

> Root URL of the resolver, without trailing /, and with scheme.
> BASE_URL = "resolver.box"

or this

> Root URL of the resolver, without trailing /, and with scheme.
> BASE_URL = "http://resolver.box"

Also, the code to generate URL's is all over the place. No point in refactoring at this point, so I just repeated the same 5 lines of code in 3 files...